### PR TITLE
Add order CRUD for delivery_man and integrate with main app

### DIFF
--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -13,6 +13,7 @@ sea-orm = "1.1.13"
 actix-web = "4"
 derive_more = "2.0.1"
 thiserror = "2.0.12"
+log = "0.4.19"
 
 [lib]
 path = "lib.rs"

--- a/crates/admin/crud_product/infrastructure/api/product_facts/order_facts_controller.rs
+++ b/crates/admin/crud_product/infrastructure/api/product_facts/order_facts_controller.rs
@@ -1,6 +1,3 @@
-use std::sync::Arc;
-use actix_web::{web::Data, web::Path, HttpResponse};
-use actix_web::web::Json;
 use crate::crud_product::application::dto::product_dto::{ProductCreateDto, ProductUpdateDto};
 use crate::crud_product::application::interface::AbstractUseCase;
 use crate::crud_product::application::product_usecases::create_product_facts_usecase::CreateProductFactsUseCase;
@@ -10,45 +7,36 @@ use crate::crud_product::application::product_usecases::get_product_by_id_facts_
 use crate::crud_product::application::product_usecases::update_product_facts_usecase::UpdateProductFactsUseCase;
 use crate::crud_product::domain::repository::ProductAbstractRepository;
 use crate::crud_product::infrastructure::api::shared::error_presenter::ErrorResponse;
-
+use actix_web::web::Json;
+use actix_web::{web::Data, web::Path, HttpResponse};
+use std::sync::Arc;
 
 pub async fn get_all_products_facts(data: Data<Arc<dyn ProductAbstractRepository>>) -> Result<HttpResponse, ErrorResponse> {
     let get_all_products_facts_uc = GetAllProductsFactsUseCase::new(data.get_ref().clone());
     let product_facts = get_all_products_facts_uc.execute().await;
-    product_facts
-        .map(|facts| HttpResponse::Ok().json(facts))
-        .map_err(ErrorResponse::map_io_error)
+    product_facts.map(|facts| HttpResponse::Ok().json(facts)).map_err(ErrorResponse::map_io_error)
 }
 
 pub async fn get_product_facts_by_id(data: Data<Arc<dyn ProductAbstractRepository>>, id: Path<i32>) -> Result<HttpResponse, ErrorResponse> {
     let get_product_uc = GetProductByIdFactsUsecase::new(data.get_ref().clone(), id.into_inner());
     let product_facts = get_product_uc.execute().await;
-    product_facts
-        .map(|facts| HttpResponse::Ok().json(facts))
-        .map_err(ErrorResponse::map_io_error)
+    product_facts.map(|facts| HttpResponse::Ok().json(facts)).map_err(ErrorResponse::map_io_error)
 }
 
 pub async fn create_product_facts(data: Data<Arc<dyn ProductAbstractRepository>>, product_create_dto: Json<ProductCreateDto>) -> Result<HttpResponse, ErrorResponse> {
     let create_product_uc = CreateProductFactsUseCase::new(data.get_ref().clone(), product_create_dto.into_inner());
     let product_facts = create_product_uc.execute().await;
-    product_facts
-        .map(|facts| HttpResponse::Created().json(facts))
-        .map_err(ErrorResponse::map_io_error)
+    product_facts.map(|facts| HttpResponse::Created().json(facts)).map_err(ErrorResponse::map_io_error)
 }
 
 pub async fn update_product_facts(data: Data<Arc<dyn ProductAbstractRepository>>, product_update_dto: Json<ProductUpdateDto>) -> Result<HttpResponse, ErrorResponse> {
     let update_product_uc = UpdateProductFactsUseCase::new(data.get_ref().clone(), product_update_dto.into_inner());
     let product_facts = update_product_uc.execute().await;
-    product_facts
-        .map(|facts| HttpResponse::Ok().json(facts))
-        .map_err(ErrorResponse::map_io_error)
+    product_facts.map(|facts| HttpResponse::Ok().json(facts)).map_err(ErrorResponse::map_io_error)
 }
 
 pub async fn delete_product_facts(data: Data<Arc<dyn ProductAbstractRepository>>, id: Path<i32>) -> Result<HttpResponse, ErrorResponse> {
     let delete_product_uc = DeleteProductFactsUseCase::new(data.get_ref().clone(), id.into_inner());
     let result = delete_product_uc.execute().await;
-    result
-        .map(|_| HttpResponse::NoContent().finish())
-        .map_err(ErrorResponse::map_io_error)
+    result.map(|_| HttpResponse::NoContent().finish()).map_err(ErrorResponse::map_io_error)
 }
-

--- a/crates/admin/crud_product/infrastructure/spi/db/db_product_facts_repository.rs
+++ b/crates/admin/crud_product/infrastructure/spi/db/db_product_facts_repository.rs
@@ -1,10 +1,11 @@
-use std::error::Error;
-use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait};
 use crate::crud_product::application::dto::product_dto::{ProductCreateDto, ProductUpdateDto};
 use crate::crud_product::domain::models::product::ProductEntity;
 use crate::crud_product::domain::repository::ProductAbstractRepository;
 use crate::crud_product::infrastructure::spi::db::db_mapper::DBMapper;
 use crate::crud_product::infrastructure::spi::db::product_entity::{ActiveModel, Entity};
+use log::info;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait};
+use std::error::Error;
 
 pub struct DbProductFactsRepository {
     connection: DatabaseConnection,
@@ -23,39 +24,44 @@ impl DbProductFactsRepository {
 #[async_trait::async_trait]
 impl ProductAbstractRepository for DbProductFactsRepository {
     async fn get_all_products(&self) -> Result<Vec<ProductEntity>, Box<dyn Error>> {
-        let products = Entity::find().all(&self.connection).await.map_err(|e| {
-            Box::new(e) as Box<dyn Error>
-        })?;
+        let products = Entity::find().all(&self.connection).await.map_err(|e| Box::new(e) as Box<dyn Error>)?;
         let product_response = products.into_iter().map(|product| DBMapper::to_entity(product)).collect();
         Ok(product_response)
     }
 
     async fn get_product_by_id(&self, id: i32) -> Result<ProductEntity, Box<dyn Error>> {
-        let product = Entity::find_by_id(id).one(&self.connection).await.map_err(|e| {Box::new(e) as Box<dyn Error>})?;
+        let product = Entity::find_by_id(id).one(&self.connection).await.map_err(|e| Box::new(e) as Box<dyn Error>)?;
         match product {
             Some(product) => Ok(DBMapper::to_entity(product)),
-            None => Err(Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "Product not found")) as Box<dyn Error>)
+            None => Err(Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "Product not found")) as Box<dyn Error>),
         }
     }
 
     async fn create_product(&self, product: ProductCreateDto) -> Result<ProductEntity, Box<dyn Error>> {
+        let log_product = format!("Creating product: {} with price {}", product.name, product.price);
+        info!("{}", log_product);
+
+        let price =
+            sea_orm::prelude::Decimal::try_from(product.price).map_err(|_| Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid price format")) as Box<dyn Error>)?;
+
         let new_product = ActiveModel {
+            id_product: sea_orm::Set(1500),
             name: sea_orm::Set(product.name),
-            price: sea_orm::Set(sea_orm::prelude::Decimal::try_from(product.price).unwrap_or_default()),
+            price: sea_orm::Set(price),
             ..Default::default()
         };
-        let inserted_product = new_product.insert(&self.connection).await.map_err(|e| {
-            Box::new(e) as Box<dyn Error>
-        })?;
-        let product_entity = DBMapper::to_entity(inserted_product);
-        Ok(product_entity)
+
+        match new_product.insert(&self.connection).await {
+            Ok(inserted_product) => {
+                let product_entity = DBMapper::to_entity(inserted_product);
+                Ok(product_entity)
+            }
+            Err(e) => Err(Box::new(e) as Box<dyn Error>),
+        }
     }
 
     async fn update_product(&self, product: ProductUpdateDto) -> Result<ProductEntity, Box<dyn Error>> {
-        let product_to_update = Entity::find_by_id(product.id_product)
-            .one(&self.connection)
-            .await
-            .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+        let product_to_update = Entity::find_by_id(product.id_product).one(&self.connection).await.map_err(|e| Box::new(e) as Box<dyn Error>)?;
         let mut updated: ActiveModel = product_to_update.unwrap().into();
         if let Some(name) = product.name {
             updated.name = sea_orm::Set(name);
@@ -63,23 +69,16 @@ impl ProductAbstractRepository for DbProductFactsRepository {
         if let Some(price) = product.price {
             updated.price = sea_orm::Set(sea_orm::prelude::Decimal::try_from(price).unwrap_or_default());
         }
-        let updated_product = updated.update(&self.connection).await.map_err(|e| {
-            Box::new(e) as Box<dyn Error>
-        })?;
+        let updated_product = updated.update(&self.connection).await.map_err(|e| Box::new(e) as Box<dyn Error>)?;
         let product_entity = DBMapper::to_entity(updated_product);
         Ok(product_entity)
     }
 
     async fn delete_product(&self, id: i32) -> Result<(), Box<dyn Error>> {
-        let product_to_delete = Entity::find_by_id(id)
-            .one(&self.connection)
-            .await
-            .map_err(|e| Box::new(e) as Box<dyn Error>)?;
+        let product_to_delete = Entity::find_by_id(id).one(&self.connection).await.map_err(|e| Box::new(e) as Box<dyn Error>)?;
         if let Some(product) = product_to_delete {
             let active_model: ActiveModel = product.into();
-            active_model.delete(&self.connection).await.map_err(|e| {
-                Box::new(e) as Box<dyn Error>
-            })?;
+            active_model.delete(&self.connection).await.map_err(|e| Box::new(e) as Box<dyn Error>)?;
             Ok(())
         } else {
             Err(Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "Product not found")) as Box<dyn Error>)

--- a/crates/delivery_man/Cargo.toml
+++ b/crates/delivery_man/Cargo.toml
@@ -6,6 +6,17 @@ authors.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+actix-web = "4"
+async-trait = "0.1.42"
+chrono = "0.4.19"
+sea-orm = { version = "1.1.12", features = [
+    "sqlx-postgres",
+    "runtime-actix-native-tls",
+] }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.73"
+
+shared = { path = "../shared" }
 
 [lib]
 path = "lib.rs"

--- a/crates/delivery_man/crud_order/application/dtos.rs
+++ b/crates/delivery_man/crud_order/application/dtos.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+use shared::entity::sea_orm_active_enums::StateOrderEnum;
+
+#[derive(Deserialize)]
+pub struct OrderCreateDto {
+    pub id_user: Option<i32>,
+    pub id_delivery_man: Option<i32>,
+    pub time: Option<String>,
+    pub delivery_address: Option<String>,
+    pub order_status: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct OrderUpdateDto {
+    pub id_order: i32,
+    pub id_user: Option<i32>,
+    pub id_delivery_man: Option<i32>,
+    pub time: Option<String>,
+    pub delivery_address: Option<String>,
+    pub order_status: Option<String>,
+}
+
+pub fn parse_order_status_to_enum(order_status: Option<String>) -> Option<StateOrderEnum> {
+    order_status.map(|status| match status.as_str() {
+        "pending" => StateOrderEnum::Pending,
+        "preparing" => StateOrderEnum::Preparing,
+        "ontheway" => StateOrderEnum::OnTheWay,
+        "delivered" => StateOrderEnum::Delivered,
+        "cancelled" => StateOrderEnum::Cancelled,
+        _ => StateOrderEnum::Pending,
+    })
+}

--- a/crates/delivery_man/crud_order/application/mod.rs
+++ b/crates/delivery_man/crud_order/application/mod.rs
@@ -1,0 +1,2 @@
+pub mod dtos;
+pub mod ucs;

--- a/crates/delivery_man/crud_order/application/ucs.rs
+++ b/crates/delivery_man/crud_order/application/ucs.rs
@@ -1,0 +1,35 @@
+// use_cases/order_use_case.rs
+use crate::crud_order::application::dtos::{OrderCreateDto, OrderUpdateDto};
+use crate::crud_order::domain::model::OrderEntity;
+use crate::crud_order::domain::repository::OrderAbstractRepository;
+use std::sync::Arc;
+
+pub struct OrderUseCase {
+    pub repo: Arc<dyn OrderAbstractRepository>,
+}
+
+impl OrderUseCase {
+    pub fn new(repo: Arc<dyn OrderAbstractRepository>) -> Self {
+        Self { repo }
+    }
+
+    pub async fn list(&self) -> Result<Vec<OrderEntity>, Box<dyn std::error::Error>> {
+        self.repo.get_all().await
+    }
+
+    pub async fn get(&self, id: i32) -> Result<OrderEntity, Box<dyn std::error::Error>> {
+        self.repo.get_by_id(id).await
+    }
+
+    pub async fn create(&self, dto: OrderCreateDto) -> Result<OrderEntity, Box<dyn std::error::Error>> {
+        self.repo.create(dto).await
+    }
+
+    pub async fn update(&self, dto: OrderUpdateDto) -> Result<OrderEntity, Box<dyn std::error::Error>> {
+        self.repo.update(dto).await
+    }
+
+    pub async fn delete(&self, id: i32) -> Result<(), Box<dyn std::error::Error>> {
+        self.repo.delete(id).await
+    }
+}

--- a/crates/delivery_man/crud_order/domain/mod.rs
+++ b/crates/delivery_man/crud_order/domain/mod.rs
@@ -1,1 +1,2 @@
+pub mod model;
 pub mod repository;

--- a/crates/delivery_man/crud_order/domain/model.rs
+++ b/crates/delivery_man/crud_order/domain/model.rs
@@ -1,0 +1,12 @@
+use chrono::NaiveDateTime;
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct OrderEntity {
+    pub id_order: i32,
+    pub id_user: Option<i32>,
+    pub id_delivery_man: Option<i32>,
+    pub time: Option<NaiveDateTime>,
+    pub delivery_address: Option<String>,
+    pub order_status: Option<String>,
+}

--- a/crates/delivery_man/crud_order/domain/repository.rs
+++ b/crates/delivery_man/crud_order/domain/repository.rs
@@ -1,0 +1,14 @@
+use crate::crud_order::application::dtos::OrderCreateDto;
+use crate::crud_order::application::dtos::OrderUpdateDto;
+use crate::crud_order::domain::model::OrderEntity;
+use async_trait::async_trait;
+use std::error::Error;
+
+#[async_trait]
+pub trait OrderAbstractRepository: Send + Sync {
+    async fn get_all(&self) -> Result<Vec<OrderEntity>, Box<dyn Error>>;
+    async fn get_by_id(&self, id: i32) -> Result<OrderEntity, Box<dyn Error>>;
+    async fn create(&self, order: OrderCreateDto) -> Result<OrderEntity, Box<dyn Error>>;
+    async fn update(&self, order: OrderUpdateDto) -> Result<OrderEntity, Box<dyn Error>>;
+    async fn delete(&self, id: i32) -> Result<(), Box<dyn Error>>;
+}

--- a/crates/delivery_man/crud_order/infrastructure/controllers.rs
+++ b/crates/delivery_man/crud_order/infrastructure/controllers.rs
@@ -1,0 +1,32 @@
+use crate::crud_order::application::dtos::{OrderCreateDto, OrderUpdateDto};
+use crate::crud_order::application::ucs::OrderUseCase;
+use actix_web::{web, HttpResponse};
+use std::sync::Arc;
+
+pub async fn list_orders(use_case: web::Data<Arc<OrderUseCase>>) -> HttpResponse {
+    match use_case.list().await {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() })),
+    }
+}
+
+pub async fn create_order(use_case: web::Data<Arc<OrderUseCase>>, dto: web::Json<OrderCreateDto>) -> HttpResponse {
+    match use_case.create(dto.into_inner()).await {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() })),
+    }
+}
+
+pub async fn update_order(use_case: web::Data<Arc<OrderUseCase>>, dto: web::Json<OrderUpdateDto>) -> HttpResponse {
+    match use_case.update(dto.into_inner()).await {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() })),
+    }
+}
+
+pub async fn delete_order(use_case: web::Data<Arc<OrderUseCase>>, id: i32) -> HttpResponse {
+    match use_case.delete(id).await {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "message": "Order deleted successfully" })),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() })),
+    }
+}

--- a/crates/delivery_man/crud_order/infrastructure/mod.rs
+++ b/crates/delivery_man/crud_order/infrastructure/mod.rs
@@ -1,0 +1,2 @@
+pub mod controllers;
+pub mod order_repository;

--- a/crates/delivery_man/crud_order/infrastructure/order_repository.rs
+++ b/crates/delivery_man/crud_order/infrastructure/order_repository.rs
@@ -1,0 +1,85 @@
+// infrastructure/order_repository_sea_orm.rs
+use crate::crud_order::application::dtos::{parse_order_status_to_enum, OrderCreateDto, OrderUpdateDto};
+use crate::crud_order::domain::model::OrderEntity;
+use crate::crud_order::domain::repository::OrderAbstractRepository;
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use sea_orm::*;
+use shared::entity::order;
+use shared::entity::sea_orm_active_enums::StateOrderEnum;
+use std::error::Error;
+
+pub struct OrderRepositorySeaOrm {
+    pub db: DatabaseConnection,
+}
+
+impl OrderRepositorySeaOrm {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl OrderAbstractRepository for OrderRepositorySeaOrm {
+    async fn get_all(&self) -> Result<Vec<OrderEntity>, Box<dyn Error>> {
+        let orders = order::Entity::find().all(&self.db).await?;
+        Ok(orders.into_iter().map(|o| o.into()).collect())
+    }
+
+    async fn get_by_id(&self, id: i32) -> Result<OrderEntity, Box<dyn Error>> {
+        let order = order::Entity::find_by_id(id).one(&self.db).await?.ok_or("Order not found")?;
+        Ok(order.into())
+    }
+
+    async fn create(&self, dto: OrderCreateDto) -> Result<OrderEntity, Box<dyn Error>> {
+        let new = order::ActiveModel {
+            id_order: NotSet,
+            id_user: Set(dto.id_user),
+            id_delivery_man: Set(dto.id_delivery_man),
+            time: Set(dto.time.map(|s| NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").unwrap())),
+            delivery_address: Set(dto.delivery_address),
+            order_status: Set(parse_order_status_to_enum(dto.order_status)),
+        };
+
+        let saved = new.insert(&self.db).await?;
+        Ok(saved.into())
+    }
+
+    async fn update(&self, dto: OrderUpdateDto) -> Result<OrderEntity, Box<dyn Error>> {
+        let mut existing = order::Entity::find_by_id(dto.id_order).one(&self.db).await?.ok_or("Order not found")?.into_active_model();
+
+        existing.id_user = Set(dto.id_user);
+        existing.id_delivery_man = Set(dto.id_delivery_man);
+        existing.time = Set(dto.time.map(|s| NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").unwrap()));
+        existing.delivery_address = Set(dto.delivery_address);
+        existing.order_status = Set(parse_order_status_to_enum(dto.order_status));
+
+        let updated = existing.update(&self.db).await?;
+        Ok(updated.into())
+    }
+
+    async fn delete(&self, id: i32) -> Result<(), Box<dyn Error>> {
+        order::Entity::delete_by_id(id).exec(&self.db).await?;
+        Ok(())
+    }
+}
+
+// conversión Entity -> Domain
+impl From<order::Model> for OrderEntity {
+    fn from(m: order::Model) -> Self {
+        Self {
+            id_order: m.id_order,
+            id_user: m.id_user,
+            id_delivery_man: m.id_delivery_man,
+            time: m.time,
+            delivery_address: m.delivery_address,
+            order_status: m.order_status.map(|status| match status {
+                StateOrderEnum::Pending => "Pending".to_string(),
+                StateOrderEnum::Preparing => "Preparing".to_string(),
+                StateOrderEnum::OnTheWay => "OnTheWay".to_string(),
+                StateOrderEnum::Delivered => "Delivered".to_string(),
+                StateOrderEnum::Cancelled => "Cancelled".to_string(),
+            }),
+        }
+    }
+}

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -15,6 +15,8 @@ user = { path = "../user" }
 tokio = { version = "1.45.1", features = ["full"] }
 actix-web = "4"
 actix-cors = "0.6"
+env_logger = "0.11.8"
+log = "0.4.17"
 dotenv = "0.15.0"
 serde = { version = "1.0.219", features = ["derive"] }
 futures-util = "0.3.31"

--- a/crates/main/actix_web_router.rs
+++ b/crates/main/actix_web_router.rs
@@ -1,19 +1,28 @@
-use std::sync::Arc;
 use actix_web::{web, HttpResponse, Scope};
+use delivery_man::crud_order::infrastructure::controllers::list_orders;
+use std::sync::Arc;
 
 use crate::{auth_user::AuthUser, bootstrap::AppState};
 
 // Registro-Login
-use register_login::credential_validation::infrastructure::{login_handler::login_handler,register_handler::register_handler,};
+use register_login::credential_validation::infrastructure::{login_handler::login_handler, register_handler::register_handler};
 
 // Orders-Billing
-use orders_billing::payment_record::{domain::repository::OrdersBillingRepository, infrastructure::{generate_invoice_handler::generate_invoice_handler,get_payment_by_order_handler::get_payment_by_order_handler,register_payment_handler::register_payment_handler,},};
+use orders_billing::payment_record::{
+    domain::repository::OrdersBillingRepository,
+    infrastructure::{generate_invoice_handler::generate_invoice_handler, get_payment_by_order_handler::get_payment_by_order_handler, register_payment_handler::register_payment_handler},
+};
 
 // User
-use user::infrastructure::controller::{product_controller::{get_all_products, get_by_purchase_for_user, get_selected_products},user_controller::rate_delivery_controller,};
+use user::infrastructure::controller::{
+    product_controller::{get_by_purchase_for_user, get_selected_products},
+    user_controller::rate_delivery_controller,
+};
 
 // Admin
-use admin::crud_product::infrastructure::api::product_facts::order_facts_controller::{create_product_facts, delete_product_facts, get_product_facts_by_id, update_product_facts,};
+use admin::crud_product::infrastructure::api::product_facts::order_facts_controller::{
+    create_product_facts, delete_product_facts, get_all_products_facts, get_product_facts_by_id, update_product_facts,
+};
 
 pub async fn protected_route(user: AuthUser) -> HttpResponse {
     HttpResponse::Ok().body(format!("Hello, {}!", user.0.user_metadata.role))
@@ -21,7 +30,6 @@ pub async fn protected_route(user: AuthUser) -> HttpResponse {
 
 pub fn configure_routes(app_state: &AppState) -> Scope {
     web::scope("/deligo")
-
         // Estado compartido
         .app_data(web::Data::new(app_state.clone()))
         .app_data(web::Data::new(Arc::clone(&app_state.credential_repo)))
@@ -29,28 +37,32 @@ pub fn configure_routes(app_state: &AppState) -> Scope {
         .app_data(web::Data::new(Arc::clone(&app_state.delivery_man_repo)))
         .app_data(web::Data::new(app_state.orders_billing_repo.clone() as Arc<dyn OrdersBillingRepository>))
         .app_data(web::Data::new(app_state.jwt_secret.clone()))
-
+        .app_data(web::Data::new(app_state.order_repo.clone()))
         // Rutas protegidas
         .route("/protected", web::get().to(protected_route))
-
         // Registro-Login
         .route("/register", web::post().to(register_handler))
         .route("/login", web::post().to(login_handler))
-
         // Orders-Billing
         .route("/payments", web::post().to(register_payment_handler))
         .route("/invoice/{order_id}", web::get().to(generate_invoice_handler))
         .route("/payments/{order_id}", web::get().to(get_payment_by_order_handler))
-
         // Usuario (cliente)
         .route("/rate-delivery", web::post().to(rate_delivery_controller))
-        .route("/products", web::get().to(get_all_products))
+        .route("/products", web::get().to(get_all_products_facts))
         .route("/products/purchase/{user_id}/{product_id}", web::get().to(get_by_purchase_for_user))
         .route("/products/selected/{user_id}", web::get().to(get_selected_products))
-
         // Admin - Product Facts
         .route("/products/{id}", web::get().to(get_product_facts_by_id))
         .route("/products", web::post().to(create_product_facts))
         .route("/products", web::patch().to(update_product_facts))
         .route("/products/{id}", web::delete().to(delete_product_facts))
+
+        // order routes
+        .route("/orders", web::get().to(list_order))
+        .route("/orders", web::post().to(create_order))
+        .route("/orders/{id}", web::get().to(get_order_by_id))
+        .route("/orders", web::patch().to(update_order))
+        .route("/orders/{id}", web::delete().to(delete_order))
+    }
 }

--- a/crates/main/bootstrap.rs
+++ b/crates/main/bootstrap.rs
@@ -5,12 +5,14 @@ use admin::crud_product::infrastructure::spi::db::db_product_facts_repository::D
 
 use shared::config::connect_to_supabase;
 
-use register_login::credential_validation::infrastructure::repository::SeaOrmUserCredentialRepository;
-use orders_billing::payment_record::domain::repository::OrdersBillingRepository;
-use orders_billing::payment_record::infrastructure::repository::SupabaseOrdersBillingRepository;
 use admin::crud_delivery_man::domain::repository::DeliveryManAbstractRepository;
 use admin::crud_delivery_man::infrastructure::spi::db_delivery_facts_repository::DbDeliveryFactsRepository;
+use delivery_man::crud_order::domain::repository::OrderAbstractRepository;
+use delivery_man::crud_order::infrastructure::order_repository::OrderRepositorySeaOrm;
+use orders_billing::payment_record::domain::repository::OrdersBillingRepository;
+use orders_billing::payment_record::infrastructure::repository::SupabaseOrdersBillingRepository;
 use register_login::credential_validation::domain::repository::UserCredentialRepository;
+use register_login::credential_validation::infrastructure::repository::SeaOrmUserCredentialRepository;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -19,17 +21,19 @@ pub struct AppState {
     pub credential_repo: Arc<dyn UserCredentialRepository>,
     pub delivery_man_repo: Arc<dyn DeliveryManAbstractRepository>,
     pub orders_billing_repo: Arc<dyn OrdersBillingRepository>,
+    pub order_repo: Arc<dyn OrderAbstractRepository>,
 }
 
 pub async fn init_state() -> Result<AppState, Box<dyn std::error::Error + Send + Sync>> {
     let db = connect_to_supabase().await?;
 
-    let supabase_jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
-        .expect("Falta la variable SUPABASE_JWT_SECRET");
+    let supabase_jwt_secret = std::env::var("SUPABASE_JWT_SECRET").expect("Falta la variable SUPABASE_JWT_SECRET");
 
     let products_repo = Arc::new(DbProductFactsRepository::new(db.clone()));
     let delivery_man_repo = Arc::new(DbDeliveryFactsRepository::new(db.clone()));
     let credential_repo = Arc::new(SeaOrmUserCredentialRepository { db: db.clone() });
+    let order_repo = Arc::new(OrderRepositorySeaOrm::new(db.clone()));
+
     let orders_billing_repo: Arc<SupabaseOrdersBillingRepository> = Arc::new(SupabaseOrdersBillingRepository::new(db.clone()));
 
     Ok(AppState {
@@ -38,5 +42,6 @@ pub async fn init_state() -> Result<AppState, Box<dyn std::error::Error + Send +
         delivery_man_repo,
         credential_repo,
         orders_billing_repo,
+        order_repo,
     })
 }

--- a/crates/main/main.rs
+++ b/crates/main/main.rs
@@ -14,6 +14,7 @@ use user::infrastructure::routes::config;
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     dotenv::dotenv().ok();
+    env_logger::init();
 
     let app_state = init_state().await.expect("Failed to initialize state");
     let user_app_state = bootstrap_user().await.expect("Failed to initialize user state");
@@ -23,7 +24,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(
                 Cors::default()
                     .allowed_origin("http://localhost:5173")
-                    .allowed_methods(vec!["GET", "POST", "PUT", "DELETE"])
+                    .allowed_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"])
                     .allowed_headers(vec!["Content-Type", "Authorization"])
                     .max_age(3600),
             )


### PR DESCRIPTION
- Implement order DTOs, domain model, repository trait, SeaORM repository, use cases, and controllers in delivery_man crate - Register order repository in main app state and wire up order routes in actix_web_router - Add required dependencies to Cargo.toml files - Enable PATCH and DELETE methods in CORS - Add logging dependencies and initialize env_logger